### PR TITLE
Fix shell command formatting in YAML file

### DIFF
--- a/tasks/detect_unused_disks.yml
+++ b/tasks/detect_unused_disks.yml
@@ -29,7 +29,7 @@
   failed_when: false
 
 - name: detect_unused_disks | Get devices with filesystem
-  shell: blkid | cut -d: -f1 | sort | uniq
+  shell: "blkid | cut -d: -f1 | sort | uniq"
   register: formatted_devices
   changed_when: false
   failed_when: false


### PR DESCRIPTION
```
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)

Syntax Error while loading YAML.
  mapping values are not allowed in this context

The error appears to be in '/home/runner/work/iac/iac/ansible/roles/ansible-mdadm/tasks/detect_unused_disks.yml': line 32, column 24, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

- name: detect_unused_disks | Get devices with filesystem
  shell: blkid | cut -d: -f1 | sort | uniq
                       ^ here
```